### PR TITLE
fix encoded link anchor at TOC

### DIFF
--- a/lib/prmd/templates/schema.erb
+++ b/lib/prmd/templates/schema.erb
@@ -1,4 +1,11 @@
-<% if options[:doc][:toc] %><%= Prmd::Template::load('table_of_contents.erb', options[:template]).result({schema: schema}) %> <%end %>
+<%- if options[:doc][:toc] -%>
+<%=
+  Prmd::Template::load('table_of_contents.erb', options[:template]).result({
+    options: options,
+    schema:  schema
+  })
+%>
+<%- end -%>
 <%=
   schemata_template = Prmd::Template::load('schemata.md.erb', options[:template])
 

--- a/lib/prmd/templates/table_of_contents.erb
+++ b/lib/prmd/templates/table_of_contents.erb
@@ -1,9 +1,11 @@
-# The table of contents
+<%- Prmd::Template.render('schemata/helper.erb', options[:template]) -%>
+## The table of contents
+
 <% schema['properties'].keys.sort.map do |key| %>
   <% resource, property = key, schema['properties'][key] %>
   <% _, schemata = schema.dereference(property) %>
-  - <a href="#resource-<%= resource %>"><%= schemata['title'].split(' - ', 2).last %></a>
+- <a href="#resource-<%= resource %>"><%= schemata['title'].split(' - ', 2).last %></a>
   <% schemata.fetch('links', []).each do |l| %>
-    - <a href="#link-<%= l['method'] %>-<%= resource %>-<%= l['href'] %>"><%= l['method'] %> <%= l['href'] %></a>
+  - <a href="#link-<%= l['method'] %>-<%= resource %>-<%= l['href'] %>"><%= l['method'] %> <%= build_link_path(schema, l) %></a>
   <% end %>
- <% end %>
+<% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In link anchor at TOC, Decode HTML meta characters using `build_link_path` helper.
and, change TOC header from `<h1>` to `<h2>`

## Motivation and Context / Screenshots
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### bad
![image](https://cloud.githubusercontent.com/assets/44050/21010173/013ae0f0-bd8e-11e6-8f0b-7bc6f26ac4f2.png)

### good
![image](https://cloud.githubusercontent.com/assets/44050/21010128/c4e93ebc-bd8d-11e6-9b1b-9fb491606efe.png)
